### PR TITLE
setup.py: remove superfluous `provides'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,4 @@ setup(name='urwidtrees',
       license=urwidtrees.__copyright__,
       packages=['urwidtrees'],
       requires=['urwid (>=1.1.0)'],
-      provides='urwidtrees',
      )


### PR DESCRIPTION
Note that the current line is interpreted as providing the packages

 u, r, w, i, d, t, e, s