### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/docs/examples/example1.py
+++ b/docs/examples/example1.py
@@ -47,12 +47,12 @@ def construct_example_simpletree_structure(selectable_nodes=True, children=3):
     # define some children
     c = g = gg = 0  # counter
     for i in range(children):
-        subtree = (Text('Child %d' % c), [])
+        subtree = (Text('Child {0:d}'.format(c)), [])
         # and grandchildren..
         for j in range(children):
-            subsubtree = (Text('Grandchild %d' % g), [])
+            subsubtree = (Text('Grandchild {0:d}'.format(g)), [])
             for k in range(children):
-                leaf = (Text('Grand Grandchild %d' % gg), None)
+                leaf = (Text('Grand Grandchild {0:d}'.format(gg)), None)
                 subsubtree[1].append(leaf)
                 gg += 1  # inc grand-grandchild counter
             subtree[1].append(subsubtree)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:pazz:urwidtrees?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:pazz:urwidtrees?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)