### PR TITLE
Add valign option to set_focus.

### DIFF
--- a/urwidtrees/widgets.py
+++ b/urwidtrees/widgets.py
@@ -119,8 +119,11 @@ class TreeBox(WidgetWrap):
     def get_focus(self):
         return self._outer_list.get_focus()
 
-    def set_focus(self, pos):
-        return self._outer_list.set_focus(pos)
+    def set_focus(self, pos, valign=None):
+        position = self._outer_list.set_focus(pos)
+        if valign:
+            position = self._outer_list.set_focus_valign(valign)
+        return position
 
     def refresh(self):
         self._walker.clear_cache()


### PR DESCRIPTION
A first attempt at getting to resolving https://github.com/pazz/alot/issues/1491

This approach adds an optional `valign` param to the `set_focus` method. An alternative would be to make a separate `set_focus_valign` method and expect the user of urwidtrees to call both methods - don't know which you prefer?

Also I noticed that in `__init__` for this `TreeBox` class it makes a call to the 'parent' `set_focus` - this should probably be done using it's own `set_focus` method to keep things DRY. I can add that as part of this PR, or make a separate one?