### PR TITLE
Replace __super with super()

### DIFF
--- a/urwidtrees/widgets.py
+++ b/urwidtrees/widgets.py
@@ -114,7 +114,7 @@ class TreeBox(WidgetWrap):
         self._outer_list = ListBox(self._walker)
         if focus is not None:
             self.set_focus(focus)
-        self.__super.__init__(self._outer_list)
+        super().__init__(self._outer_list)
 
     # Widget API
     def get_focus(self):


### PR DESCRIPTION
Support for the __super property has been removed in urwid commit 9378442 [1].

Fixes issue #52.

[1] https://github.com/urwid/urwid/commit/9378442